### PR TITLE
Implement password update 

### DIFF
--- a/src/main/java/com/gtu/users_management_service/application/service/UserServiceImpl.java
+++ b/src/main/java/com/gtu/users_management_service/application/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.domain.model.Role;
 import com.gtu.users_management_service.domain.model.Status;
 import com.gtu.users_management_service.domain.model.User;
@@ -88,4 +89,24 @@ public class UserServiceImpl implements UserService {
         }
         return users;
     }    
+
+    @Override
+    public User updatePassword(User user, PasswordUpdateDTO passwordUpdateDTO) {
+        User existingUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Passenger not found"));
+        if(user.getPassword() == null || user.getPassword().isEmpty()) {
+            throw new IllegalArgumentException("Current password cannot be null or empty");
+        }
+        if (!PasswordEncoderUtil.matches(user.getPassword(), existingUser.getPassword())) {
+            throw new IllegalArgumentException("Current password is incorrect");
+        }
+        if (passwordUpdateDTO.getNewPassword() == null || passwordUpdateDTO.getNewPassword().isEmpty()) {
+            throw new IllegalArgumentException("New password cannot be null or empty");
+        }
+        if (!PasswordValidator.isValid(passwordUpdateDTO.getNewPassword())) {
+            throw new IllegalArgumentException("New password must contain at least 8 characters, including uppercase letters and numbers");
+        }
+        existingUser.setPassword(PasswordEncoderUtil.encode(passwordUpdateDTO.getNewPassword()));
+        return userRepository.save(existingUser);
+    }
 }

--- a/src/main/java/com/gtu/users_management_service/application/usecase/UserUseCase.java
+++ b/src/main/java/com/gtu/users_management_service/application/usecase/UserUseCase.java
@@ -1,5 +1,6 @@
 package com.gtu.users_management_service.application.usecase;
 
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.application.dto.UserDTO;
 import com.gtu.users_management_service.application.mapper.UserMapper;
 import com.gtu.users_management_service.domain.model.Role;
@@ -33,5 +34,14 @@ public class UserUseCase {
 
     public List<UserDTO> getUsersByRole(Role role) {
         return UserMapper.toDTOList(userService.getUsersByRole(role));
+    }
+
+    public UserDTO updatePassword(UserDTO userDTO, PasswordUpdateDTO passwordUpdateDTO) {
+        return UserMapper.toDTO(
+            userService.updatePassword(
+                UserMapper.toDomain(userDTO),
+                passwordUpdateDTO
+            )
+        );
     }
 }

--- a/src/main/java/com/gtu/users_management_service/domain/service/UserService.java
+++ b/src/main/java/com/gtu/users_management_service/domain/service/UserService.java
@@ -2,6 +2,7 @@ package com.gtu.users_management_service.domain.service;
 
 import java.util.List;
 
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.domain.model.Role;
 import com.gtu.users_management_service.domain.model.Status;
 import com.gtu.users_management_service.domain.model.User;
@@ -11,4 +12,5 @@ public interface UserService {
     void deleteUser(Long id);
     User updateStatus(Long id, Status status);
     List<User> getUsersByRole(Role role);
+    User updatePassword(User user, PasswordUpdateDTO passwordUpdateDTO);
 }

--- a/src/main/java/com/gtu/users_management_service/presentation/rest/UserController.java
+++ b/src/main/java/com/gtu/users_management_service/presentation/rest/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.application.dto.ResponseDTO;
 import com.gtu.users_management_service.application.dto.UserDTO;
 import com.gtu.users_management_service.application.usecase.UserUseCase;
@@ -63,5 +64,15 @@ public class UserController {
     public ResponseEntity<ResponseDTO<List<UserDTO>>> getUsersByRole(@RequestParam Role role) {
         List<UserDTO> users = userUseCase.getUsersByRole(role);
         return ResponseEntity.ok(new ResponseDTO<>("Users retrieved successfully", users, 200));
+    }
+
+    @PutMapping("/{id}/password")
+    @Operation(summary = "Update user password", description = "Update the password of an existing user.")
+    public ResponseEntity<ResponseDTO<UserDTO>> updatePassword(@PathVariable Long id, @Valid @RequestBody PasswordUpdateDTO passwordUpdateDTO) {
+        UserDTO userDTO = new UserDTO();
+        userDTO.setId(id);
+        userDTO.setPassword(passwordUpdateDTO.getCurrentPassword());
+        UserDTO updatedUser= userUseCase.updatePassword(userDTO, passwordUpdateDTO);
+        return ResponseEntity.ok(new ResponseDTO<>("User password updated successfully", updatedUser, 200));
     }
 }

--- a/src/test/java/com/gtu/users_management_service/application/usecase/UserUseCaseTest.java
+++ b/src/test/java/com/gtu/users_management_service/application/usecase/UserUseCaseTest.java
@@ -55,6 +55,10 @@ class UserUseCaseTest {
         userDto.setPassword("Passw0rd");
         userDto.setRole(Role.ADMIN);
         userDto.setStatus(Status.ACTIVE);
+
+        passwordUpdateDTO = new PasswordUpdateDTO();
+        passwordUpdateDTO.setCurrentPassword("Passw0rd");
+        passwordUpdateDTO.setNewPassword("NewPassw0rd");
     }
 
     @Test

--- a/src/test/java/com/gtu/users_management_service/application/usecase/UserUseCaseTest.java
+++ b/src/test/java/com/gtu/users_management_service/application/usecase/UserUseCaseTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.application.dto.UserDTO;
 import com.gtu.users_management_service.domain.model.Role;
 import com.gtu.users_management_service.domain.model.Status;
@@ -35,6 +36,7 @@ class UserUseCaseTest {
 
     private User user;
     private UserDTO userDto;
+    private PasswordUpdateDTO passwordUpdateDTO;
 
     @BeforeEach
     void setUp() {
@@ -182,5 +184,32 @@ class UserUseCaseTest {
         assertEquals("Invalid role", exception.getMessage());
         verify(userService, times(1)).getUsersByRole(null);
     }
-    
+
+    @Test
+    void updatePassword_Success() {
+        user.setPassword("NewPassw0rd");
+        when(userService.updatePassword(any(User.class), any(PasswordUpdateDTO.class))).thenReturn(user);
+        UserDTO result = userUseCase.updatePassword(userDto, passwordUpdateDTO);
+
+        assertNotNull(result);
+        assertEquals(user.getId(), result.getId());
+        assertEquals(user.getName(), result.getName());
+        assertEquals(user.getEmail(), result.getEmail());
+        assertEquals("NewPassw0rd", result.getPassword());
+
+        verify(userService, times(1)).updatePassword(any(User.class), any(PasswordUpdateDTO.class));
+    }
+
+    @Test
+    void updatePassword_InvalidCurrentPassword() {
+        when(userService.updatePassword(any(User.class), any(PasswordUpdateDTO.class)))
+                .thenThrow(new IllegalArgumentException("Invalid current password"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            userUseCase.updatePassword(userDto, passwordUpdateDTO);
+        });
+        assertEquals("Invalid current password", exception.getMessage());
+
+        verify(userService, times(1)).updatePassword(any(User.class), any(PasswordUpdateDTO.class));
+    }
 }

--- a/src/test/java/com/gtu/users_management_service/presentation/rest/UserControllerTest.java
+++ b/src/test/java/com/gtu/users_management_service/presentation/rest/UserControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gtu.users_management_service.application.dto.PasswordUpdateDTO;
 import com.gtu.users_management_service.application.dto.UserDTO;
 import com.gtu.users_management_service.application.usecase.UserUseCase;
 import com.gtu.users_management_service.domain.model.Role;
@@ -43,6 +43,7 @@ class UserControllerTest {
     private ObjectMapper objectMapper;
 
     private UserDTO userDto;
+    private PasswordUpdateDTO passwordUpdateDTO;
 
     @BeforeEach
     void setUp() {
@@ -60,6 +61,10 @@ class UserControllerTest {
         userDto.setPassword("Passw0rd");
         userDto.setRole(Role.ADMIN);
         userDto.setStatus(Status.ACTIVE);
+
+        passwordUpdateDTO = new PasswordUpdateDTO();
+        passwordUpdateDTO.setCurrentPassword("Passw0rd");
+        passwordUpdateDTO.setNewPassword("NewPassw0rd");
     }
 
     @Test
@@ -187,5 +192,44 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data").isEmpty());
 
         verify(userUseCase, times(1)).getUsersByRole(Role.DRIVER);
+    }
+
+    @Test
+    void updatePassword_Success() throws Exception {
+        UserDTO updatedUserDTO = new UserDTO();
+        updatedUserDTO.setId(1L);
+        updatedUserDTO.setName("John Doe");
+        updatedUserDTO.setEmail("johndoe@example.com");
+        updatedUserDTO.setPassword("NewPassw0rd");
+
+        when(userUseCase.updatePassword(any(UserDTO.class), any(PasswordUpdateDTO.class)))
+                .thenReturn(updatedUserDTO);
+
+        mockMvc.perform(put("/users/1/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(passwordUpdateDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("User password updated successfully"))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.id").value(updatedUserDTO.getId()))
+                .andExpect(jsonPath("$.data.name").value(updatedUserDTO.getName()))
+                .andExpect(jsonPath("$.data.email").value(updatedUserDTO.getEmail()))
+                .andExpect(jsonPath("$.data.password").value("NewPassw0rd"));
+
+        verify(userUseCase, times(1)).updatePassword(any(UserDTO.class), any(PasswordUpdateDTO.class));
+    }
+
+    @Test
+    void updatePassword_InvalidCurrentPassword() throws Exception {
+        when(userUseCase.updatePassword(any(UserDTO.class), any(PasswordUpdateDTO.class)))
+                .thenThrow(new IllegalArgumentException("Invalid current password"));
+
+        mockMvc.perform(put("/users/1/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(passwordUpdateDTO)))
+                .andExpect(status().isBadRequest()) 
+                .andExpect(jsonPath("$.message").value("Invalid current password"));
+
+        verify(userUseCase, times(1)).updatePassword(any(UserDTO.class), any(PasswordUpdateDTO.class));
     }
 }

--- a/src/test/java/com/gtu/users_management_service/presentation/rest/UserControllerTest.java
+++ b/src/test/java/com/gtu/users_management_service/presentation/rest/UserControllerTest.java
@@ -188,5 +188,4 @@ class UserControllerTest {
 
         verify(userUseCase, times(1)).getUsersByRole(Role.DRIVER);
     }
-
 }


### PR DESCRIPTION
This pull request introduces a new feature for updating user passwords in the `users_management_service` application. The changes include updates across multiple layers of the application, from the controller to the service and domain layers, as well as the addition of validation and encoding for password updates.

### New Password Update Feature:

* **Controller Layer**:
  - Added a new `@PutMapping` endpoint in `UserController` to handle password updates. This endpoint accepts a `PasswordUpdateDTO` object and returns the updated user details.
  
* **Use Case Layer**:
  - Introduced the `updatePassword` method in `UserUseCase`, which maps the input DTOs to domain models, delegates the update operation to the service layer, and maps the result back to a DTO.

* **Service Layer**:
  - Added the `updatePassword` method in `UserServiceImpl` to perform the actual password update. This includes:
    - Fetching the existing user.
    - Validating the current password.
    - Validating the new password against specific criteria (e.g., length, uppercase letters, numbers).
    - Encoding the new password before saving it.
  - Declared the `updatePassword` method in the `UserService` interface.

* **DTO and Validation**:
  - Introduced the `PasswordUpdateDTO` class to encapsulate the current and new password details for the update operation. (Referenced in multiple files: [[1]](diffhunk://#diff-5a9c118aa99cbfb5c4cd174f0feac8cdf4ffeee3ff00d741e70caa4857817b64R17) [[2]](diffhunk://#diff-1a13b3d8904ff102ab225b8ff31b949831a81cab14fdbf60c283cb67509797b7R3) [[3]](diffhunk://#diff-fcea08561210f89b9aeca0f47af2568b2194a79c86c09acf6bf2f9b4b91a6398R5)

These changes collectively enable secure and validated password updates for users, ensuring proper separation of concerns and adherence to best practices in the application architecture.