### PR TITLE
Remove CrossOrigin annotation from PassengerController and UserContro…

### DIFF
--- a/src/main/java/com/gtu/users_management_service/presentation/rest/PassengerController.java
+++ b/src/main/java/com/gtu/users_management_service/presentation/rest/PassengerController.java
@@ -1,7 +1,6 @@
 package com.gtu.users_management_service.presentation.rest;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 @RestController
 @RequestMapping("/passengers")
 @Tag(name = "Passenger", description = "Endpoints for managing passengers")
-@CrossOrigin(origins = "*")
 public class PassengerController {
     
     private final PassengerUseCase passengerUseCase;

--- a/src/main/java/com/gtu/users_management_service/presentation/rest/UserController.java
+++ b/src/main/java/com/gtu/users_management_service/presentation/rest/UserController.java
@@ -3,7 +3,6 @@ package com.gtu.users_management_service.presentation.rest;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,7 +27,6 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/users")
 @Tag(name = "Users", description = "Endpoints for managing users")
-@CrossOrigin(origins = "*")
 public class UserController {
 
     private final UserUseCase userUseCase;


### PR DESCRIPTION
This pull request removes the `@CrossOrigin` annotation from the `PassengerController` and `UserController` classes in the `users_management_service` module. This change simplifies the code by eliminating the explicit configuration for cross-origin requests, possibly moving this configuration elsewhere or relying on default settings.

Changes related to `PassengerController`:

* Removed the `@CrossOrigin` annotation from the class definition in `PassengerController.java`.
* Deleted the import statement for `CrossOrigin` as it is no longer needed.

Changes related to `UserController`:

* Removed the `@CrossOrigin` annotation from the class definition in `UserController.java`.
* Deleted the import statement for `CrossOrigin` as it is no longer needed.…ller