### PR TITLE
Refactor: Update Passenger and User internal controllers to return ResponseEntity for better error handling

### DIFF
--- a/src/main/java/com/gtu/users_management_service/presentation/rest/internal/PassengerInternalController.java
+++ b/src/main/java/com/gtu/users_management_service/presentation/rest/internal/PassengerInternalController.java
@@ -9,6 +9,9 @@ import com.gtu.users_management_service.domain.model.Passenger;
 import com.gtu.users_management_service.domain.service.PassengerService;
 
 import io.swagger.v3.oas.annotations.Hidden;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -23,16 +26,28 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class PassengerInternalController {
 
     private final PassengerService passengerService;
+    private static final String PASSENGER_NOT_FOUND = "Passenger not found";
 
     public PassengerInternalController(PassengerService passengerService) {
         this.passengerService = passengerService;
     }
 
 
-    @GetMapping 
-    public Passenger getPassengerByEmail(@RequestParam String email){
-        return passengerService.getPassengerByEmail(email);
-    }  
+    @GetMapping
+    public ResponseEntity<Passenger> getPassengerByEmail(@RequestParam String email) {
+        try {
+            Passenger passenger = passengerService.getPassengerByEmail(email);
+            return ResponseEntity.ok(passenger);
+        } catch (IllegalArgumentException e) {
+            if (PASSENGER_NOT_FOUND.equals(e.getMessage())) {
+                return ResponseEntity.ok(new Passenger());
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 
     @PutMapping("/{id}/reset-password")
     public Passenger resetPassword(@PathVariable Long id, @RequestParam String newPassword) {

--- a/src/main/java/com/gtu/users_management_service/presentation/rest/internal/UserInternalController.java
+++ b/src/main/java/com/gtu/users_management_service/presentation/rest/internal/UserInternalController.java
@@ -8,6 +8,9 @@ import com.gtu.users_management_service.domain.model.User;
 import com.gtu.users_management_service.domain.service.UserService;
 
 import io.swagger.v3.oas.annotations.Hidden;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -21,14 +24,27 @@ public class UserInternalController {
 
     private final UserService userService;
 
+    private static final String USER_NOT_FOUND = "User does not exist";
+
     public UserInternalController(UserService userService) {
         this.userService = userService;
     }
 
 
     @GetMapping
-    public User getUserByEmail(@RequestParam String email){
-        return userService.getUserByEmail(email);
+    public ResponseEntity<User> getUserByEmail(@RequestParam String email) {
+        try {
+            User user = userService.getUserByEmail(email);
+            return ResponseEntity.ok(user); 
+        } catch (IllegalArgumentException e) {
+            if (USER_NOT_FOUND.equals(e.getMessage())) {
+                return ResponseEntity.ok(new User()); 
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
     
     @PutMapping("/{id}/reset-password")

--- a/src/test/java/com/gtu/users_management_service/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/gtu/users_management_service/application/service/UserServiceImplTest.java
@@ -82,7 +82,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    void createUser_shouldCreateWhenDataIsValid() throws Exception {
+    void createUser_shouldCreateWhenDataIsValid() {
         when(userRepository.existsByEmail("carlos.perez@gtu.com")).thenReturn(false);
         when(userRepository.save(user)).thenReturn(user);
 
@@ -101,13 +101,6 @@ class UserServiceImplTest {
     void createUser_shouldThrowWhenUserIsNull() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> userService.createUser(null));
         assertEquals("User cannot be null", exception.getMessage());
-    }
-
-    @Test
-    void createUser_shouldThrowWhenNameIsEmpty() {
-        user.setName("");
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> userService.createUser(user));
-        assertEquals("User name cannot be empty", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/gtu/users_management_service/infrastructure/logs/LogPublisherTest.java
+++ b/src/test/java/com/gtu/users_management_service/infrastructure/logs/LogPublisherTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MockitoExtension.class)
-public class LogPublisherTest {
+class LogPublisherTest {
 
     @Mock
     private AmqpTemplate amqpTemplate;

--- a/src/test/java/com/gtu/users_management_service/presentation/rest/internal/PassengerInternalControllerTest.java
+++ b/src/test/java/com/gtu/users_management_service/presentation/rest/internal/PassengerInternalControllerTest.java
@@ -1,36 +1,19 @@
 package com.gtu.users_management_service.presentation.rest.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gtu.users_management_service.application.dto.PassengerDTO;
-import com.gtu.users_management_service.domain.exception.ResourceNotFoundException;
 import com.gtu.users_management_service.domain.model.Passenger;
 import com.gtu.users_management_service.domain.service.PassengerService;
-import com.gtu.users_management_service.presentation.exception.GlobalExceptionHandler;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 class PassengerInternalControllerTest {
-
-    private MockMvc mockMvc;
 
     @Mock
     private PassengerService passengerService;
@@ -38,141 +21,86 @@ class PassengerInternalControllerTest {
     @InjectMocks
     private PassengerInternalController passengerInternalController;
 
-    private ObjectMapper objectMapper;
-
     @BeforeEach
     void setUp() {
-        objectMapper = new ObjectMapper();
-
-        mockMvc = MockMvcBuilders.standaloneSetup(passengerInternalController)
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
-                .build();
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
-    void getPassengerByEmail_ReturnsPassenger() throws Exception {
-        Passenger passenger = new Passenger();
-        passenger.setId(1L);
-        passenger.setName("John Doe");
-        passenger.setEmail("john.doe@example.com");
+    void getPassengerByEmail_shouldReturnPassengerWhenFound() {
+        Passenger passenger = new Passenger(1L, "Juan Pérez", "juan.perez@gtu.com", "Passw0rd");
+        when(passengerService.getPassengerByEmail("juan.perez@gtu.com")).thenReturn(passenger);
 
-        Mockito.when(passengerService.getPassengerByEmail("john.doe@example.com"))
-               .thenReturn(passenger);
+        ResponseEntity<Passenger> response = passengerInternalController.getPassengerByEmail("juan.perez@gtu.com");
 
-        mockMvc.perform(get("/internal/passengers")
-                .param("email", "john.doe@example.com"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(1)))
-            .andExpect(jsonPath("$.name", is("John Doe")))
-            .andExpect(jsonPath("$.email", is("john.doe@example.com")));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(passenger, response.getBody());
+        verify(passengerService).getPassengerByEmail("juan.perez@gtu.com");
     }
 
     @Test
-    void getPassengerByEmail_ReturnsNotFound_WhenPassengerDoesNotExist() throws Exception {
-        Mockito.when(passengerService.getPassengerByEmail("notfound@example.com"))
-            .thenThrow(new ResourceNotFoundException("Passenger not found with email: notfound@example.com"));
+    void getPassengerByEmail_shouldReturnEmptyPassengerWhenNotFound() {
+        when(passengerService.getPassengerByEmail("notfound@gtu.com"))
+                .thenThrow(new IllegalArgumentException("Passenger not found"));
 
-        mockMvc.perform(get("/internal/passengers")
-                .param("email", "notfound@example.com"))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.error").value("Not Found"))
-            .andExpect(jsonPath("$.message").value("Passenger not found with email: notfound@example.com"))
-            .andExpect(jsonPath("$.path").value("/internal/passengers"));
+        ResponseEntity<Passenger> response = passengerInternalController.getPassengerByEmail("notfound@gtu.com");
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertNull(response.getBody().getId()); 
+        verify(passengerService).getPassengerByEmail("notfound@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsUpdatedPassenger() throws Exception {
-        Passenger passenger = new Passenger();
-        passenger.setId(1L);
-        passenger.setPassword("NewPassw0rd");
+    void getPassengerByEmail_shouldReturnInternalServerErrorWhenOtherIllegalArgumentException() {
+        when(passengerService.getPassengerByEmail("invalid@gtu.com"))
+                .thenThrow(new IllegalArgumentException("Invalid input"));
 
-        Mockito.when(passengerService.resetPassword(any(Passenger.class), eq("NewPassw0rd")))
-               .thenReturn(passenger);
+        ResponseEntity<Passenger> response = passengerInternalController.getPassengerByEmail("invalid@gtu.com");
 
-        mockMvc.perform(put("/internal/passengers/1/reset-password")
-                .param("newPassword", "NewPassw0rd"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(1)))
-            .andExpect(jsonPath("$.password", is("NewPassw0rd")));
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(passengerService).getPassengerByEmail("invalid@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsNotFound_WhenPassengerDoesNotExist() throws Exception {
-        Mockito.when(passengerService.resetPassword(any(Passenger.class), eq("noSuchPass")))
-            .thenThrow(new ResourceNotFoundException("Passenger not found with ID: 99"));
+    void getPassengerByEmail_shouldReturnInternalServerErrorWhenGenericException() {
+        when(passengerService.getPassengerByEmail("error@gtu.com"))
+                .thenThrow(new RuntimeException("Unexpected error"));
 
-        mockMvc.perform(put("/internal/passengers/99/reset-password")
-                .param("newPassword", "noSuchPass"))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.error").value("Not Found"))
-            .andExpect(jsonPath("$.message").value("Passenger not found with ID: 99"))
-            .andExpect(jsonPath("$.path").value("/internal/passengers/99/reset-password"));
+        ResponseEntity<Passenger> response = passengerInternalController.getPassengerByEmail("error@gtu.com");
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(passengerService).getPassengerByEmail("error@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsBadRequest_WhenInvalidPassword() throws Exception {
-        Passenger passenger = new Passenger();
-        passenger.setId(1L);
+    void resetPassword_shouldReturnUpdatedPassengerWhenSuccessful() {
+        Passenger passenger = new Passenger(1L, "Juan Pérez", "juan.perez@gtu.com", "OldPass");
+        when(passengerService.resetPassword(any(Passenger.class), eq("NewPass1"))).thenReturn(passenger);
 
-        Mockito.when(passengerService.resetPassword(any(Passenger.class), eq("123")))
-            .thenThrow(new IllegalArgumentException("Password too short"));
+        Passenger result = passengerInternalController.resetPassword(1L, "NewPass1");
 
-        mockMvc.perform(put("/internal/passengers/1/reset-password")
-                .param("newPassword", "123"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("Bad Request"))
-            .andExpect(jsonPath("$.message").value("Password too short"));
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Juan Pérez", result.getName());
+        verify(passengerService).resetPassword(any(Passenger.class), eq("NewPass1"));
     }
 
     @Test
-    void postMethodName_CreatesPassengerSuccessfully() throws Exception {
-        PassengerDTO passengerDTO = new PassengerDTO();
-        passengerDTO.setId(2L);
-        passengerDTO.setName("Alice");
-        passengerDTO.setEmail("alice@example.com");
-        passengerDTO.setPassword("StrongPass123");
+    void resetPassword_shouldThrowExceptionWhenServiceFails() {
+        when(passengerService.resetPassword(any(Passenger.class), eq("NewPass1")))
+                .thenThrow(new IllegalArgumentException("Invalid password"));
 
-        Passenger createdPassenger = new Passenger(
-            passengerDTO.getId(),
-            passengerDTO.getName(),
-            passengerDTO.getEmail(),
-            passengerDTO.getPassword()
-        );
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            passengerInternalController.resetPassword(1L, "NewPass1"));
 
-        Mockito.when(passengerService.createPassenger(any(Passenger.class)))
-            .thenReturn(createdPassenger);
-
-        mockMvc.perform(post("/internal/passengers")
-                .contentType("application/json")
-                .content(objectMapper.writeValueAsString(passengerDTO)))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(2)))
-            .andExpect(jsonPath("$.name", is("Alice")))
-            .andExpect(jsonPath("$.email", is("alice@example.com")))
-            .andExpect(jsonPath("$.password", is("StrongPass123")));
-    }
-
-    @Test
-    void postMethodName_ReturnsBadRequest_WhenInvalidInput() throws Exception {
-        PassengerDTO passengerDTO = new PassengerDTO();
-        passengerDTO.setId(3L);
-        passengerDTO.setEmail("invalid@example.com");
-        passengerDTO.setPassword("pass");
-
-        Mockito.when(passengerService.createPassenger(any(Passenger.class)))
-            .thenThrow(new IllegalArgumentException("Name is required"));
-
-        mockMvc.perform(post("/internal/passengers")
-                .contentType("application/json")
-                .content(objectMapper.writeValueAsString(passengerDTO)))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("Bad Request"))
-            .andExpect(jsonPath("$.message").value("Name is required"));
+        assertEquals("Invalid password", exception.getMessage());
+        verify(passengerService).resetPassword(any(Passenger.class), eq("NewPass1"));
     }
 }
-

--- a/src/test/java/com/gtu/users_management_service/presentation/rest/internal/UserInternalControllerTest.java
+++ b/src/test/java/com/gtu/users_management_service/presentation/rest/internal/UserInternalControllerTest.java
@@ -1,35 +1,19 @@
 package com.gtu.users_management_service.presentation.rest.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gtu.users_management_service.domain.exception.ResourceNotFoundException;
-import com.gtu.users_management_service.domain.model.Role;
-import com.gtu.users_management_service.domain.model.Status;
 import com.gtu.users_management_service.domain.model.User;
 import com.gtu.users_management_service.domain.service.UserService;
-import com.gtu.users_management_service.presentation.exception.GlobalExceptionHandler;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 class UserInternalControllerTest {
-
-    private MockMvc mockMvc;
 
     @Mock
     private UserService userService;
@@ -37,96 +21,86 @@ class UserInternalControllerTest {
     @InjectMocks
     private UserInternalController userInternalController;
 
-    private ObjectMapper objectMapper;
-
     @BeforeEach
     void setUp() {
-        objectMapper = new ObjectMapper();
-
-        mockMvc = MockMvcBuilders.standaloneSetup(userInternalController)
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
-                .build();
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
-    void getUserByEmail_ReturnsUser() throws Exception {
-        User user = new User();
-        user.setId(1L);
-        user.setName("Carlos Pérez");
-        user.setEmail("carlos.perez@gtu.com");
-        user.setRole(Role.ADMIN);
-        user.setStatus(Status.ACTIVE);
+    void getUserByEmail_shouldReturnUserWhenFound() {
+        User user = new User(1L, "Carlos Pérez", "carlos.perez@gtu.com", "Passw0rd", null, null);
+        when(userService.getUserByEmail("carlos.perez@gtu.com")).thenReturn(user);
 
-        Mockito.when(userService.getUserByEmail("carlos.perez@gtu.com"))
-               .thenReturn(user);
+        ResponseEntity<User> response = userInternalController.getUserByEmail("carlos.perez@gtu.com");
 
-        mockMvc.perform(get("/internal/users")
-                .param("email", "carlos.perez@gtu.com"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(1)))
-            .andExpect(jsonPath("$.name", is("Carlos Pérez")))
-            .andExpect(jsonPath("$.email", is("carlos.perez@gtu.com")))
-            .andExpect(jsonPath("$.role", is("ADMIN")))
-            .andExpect(jsonPath("$.status", is("ACTIVE")));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(user, response.getBody());
+        verify(userService).getUserByEmail("carlos.perez@gtu.com");
     }
 
     @Test
-    void getUserByEmail_ReturnsNotFound_WhenUserDoesNotExist() throws Exception {
-        Mockito.when(userService.getUserByEmail("no.exists@gtu.com"))
-            .thenThrow(new ResourceNotFoundException("User not found with email: no.exists@gtu.com"));
+    void getUserByEmail_shouldReturnEmptyUserWhenNotFound() {
+        when(userService.getUserByEmail("notfound@gtu.com"))
+                .thenThrow(new IllegalArgumentException("User does not exist"));
 
-        mockMvc.perform(get("/internal/users")
-                .param("email", "no.exists@gtu.com"))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.error").value("Not Found"))
-            .andExpect(jsonPath("$.message").value("User not found with email: no.exists@gtu.com"))
-            .andExpect(jsonPath("$.path").value("/internal/users"));
+        ResponseEntity<User> response = userInternalController.getUserByEmail("notfound@gtu.com");
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertNull(response.getBody().getId()); // Verifica que es un User vacío
+        verify(userService).getUserByEmail("notfound@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsUpdatedUser() throws Exception {
-        User user = new User();
-        user.setId(1L);
-        user.setPassword("NewSecurePass");
+    void getUserByEmail_shouldReturnInternalServerErrorWhenOtherIllegalArgumentException() {
+        when(userService.getUserByEmail("invalid@gtu.com"))
+                .thenThrow(new IllegalArgumentException("Invalid input"));
 
-        Mockito.when(userService.resetPassword(any(User.class), eq("NewSecurePass")))
-               .thenReturn(user);
+        ResponseEntity<User> response = userInternalController.getUserByEmail("invalid@gtu.com");
 
-        mockMvc.perform(put("/internal/users/1/reset-password")
-                .param("newPassword", "NewSecurePass"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(1)))
-            .andExpect(jsonPath("$.password", is("NewSecurePass")));
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(userService).getUserByEmail("invalid@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsNotFound_WhenUserDoesNotExist() throws Exception {
-        Mockito.when(userService.resetPassword(any(User.class), eq("noSuchPass")))
-            .thenThrow(new ResourceNotFoundException("User not found with ID: 99"));
+    void getUserByEmail_shouldReturnInternalServerErrorWhenGenericException() {
+        when(userService.getUserByEmail("error@gtu.com"))
+                .thenThrow(new RuntimeException("Unexpected error"));
 
-        mockMvc.perform(put("/internal/users/99/reset-password")
-                .param("newPassword", "noSuchPass"))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.error").value("Not Found"))
-            .andExpect(jsonPath("$.message").value("User not found with ID: 99"))
-            .andExpect(jsonPath("$.path").value("/internal/users/99/reset-password"));
+        ResponseEntity<User> response = userInternalController.getUserByEmail("error@gtu.com");
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+        verify(userService).getUserByEmail("error@gtu.com");
     }
 
     @Test
-    void resetPassword_ReturnsBadRequest_WhenInvalidPassword() throws Exception {
-        Mockito.when(userService.resetPassword(any(User.class), eq("123")))
-            .thenThrow(new IllegalArgumentException("Password is too weak"));
+    void resetPassword_shouldReturnUpdatedUserWhenSuccessful() {
+        User user = new User(1L, "Carlos Pérez", "carlos.perez@gtu.com", "OldPass", null, null);
+        when(userService.resetPassword(any(User.class), eq("NewPass1"))).thenReturn(user);
 
-        mockMvc.perform(put("/internal/users/1/reset-password")
-                .param("newPassword", "123"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("Bad Request"))
-            .andExpect(jsonPath("$.message").value("Password is too weak"))
-            .andExpect(jsonPath("$.path").value("/internal/users/1/reset-password"));
+        User result = userInternalController.resetPassword(1L, "NewPass1");
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals("Carlos Pérez", result.getName());
+        verify(userService).resetPassword(any(User.class), eq("NewPass1"));
     }
 
+    @Test
+    void resetPassword_shouldThrowExceptionWhenServiceFails() {
+        when(userService.resetPassword(any(User.class), eq("NewPass1")))
+                .thenThrow(new IllegalArgumentException("Invalid password"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+            userInternalController.resetPassword(1L, "NewPass1"));
+
+        assertEquals("Invalid password", exception.getMessage());
+        verify(userService).resetPassword(any(User.class), eq("NewPass1"));
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes to improve error handling, simplify test cases, and enhance code readability in the `users_management_service` module. The most significant changes include updates to the `PassengerInternalController` and `UserInternalController` to return `ResponseEntity` objects for better HTTP response management, removal of redundant test cases, and refactoring of test classes to eliminate unnecessary dependencies.

### Controller Enhancements:
* **Improved error handling in `PassengerInternalController` and `UserInternalController`:** Updated the `getPassengerByEmail` and `getUserByEmail` methods to return `ResponseEntity` objects, providing more granular HTTP status codes and handling specific exceptions like `IllegalArgumentException`. Added constants for error messages (`PASSENGER_NOT_FOUND` and `USER_NOT_FOUND`) to improve code clarity. [[1]](diffhunk://#diff-59ffda7c215c129ca0f6d2246cdfe4eb5d0725b56770d5f0a817bc0e7bbcac5bR29-R49) [[2]](diffhunk://#diff-022e33eb8da501c9dca4aca83671ff0e4a163a9f20dbc51c131141864922a212R27-R47)

### Test Simplifications:
* **Refactored `PassengerInternalControllerTest`:** Removed integration-style tests that relied on `MockMvc` and replaced them with unit tests directly invoking controller methods. This simplifies the test setup and focuses on controller logic rather than HTTP request simulation.
* **Removed redundant test cases in `UserServiceImplTest`:** Deleted the test for `createUser_shouldThrowWhenNameIsEmpty` as it was unnecessary, consolidating error handling tests for invalid user input.

### Code Cleanup:
* **Modified `LogPublisherTest`:** Changed the class from `public` to `package-private` to adhere to best practices for test class visibility.

These changes collectively improve the maintainability and robustness of the `users_management_service` module.